### PR TITLE
Show query time after the query is done

### DIFF
--- a/src/mqueryfront/src/QueryTimer.js
+++ b/src/mqueryfront/src/QueryTimer.js
@@ -37,8 +37,13 @@ class QueryTimer extends Component {
     }
 
     render() {
-        if (!this.props.job.submitted || this.props.isFinished) {
+        if (!this.props.job.submitted) {
             return null;
+        }
+
+        if (this.props.isFinished) {
+            const duration = this.props.job.finished - this.props.job.submitted;
+            return <i>took {this.getRenderTime(duration)}</i>;
         }
 
         let durationSec;

--- a/src/schema.py
+++ b/src/schema.py
@@ -10,6 +10,7 @@ class JobSchema(BaseModel):
     rule_author: Optional[str]
     raw_yara: str
     submitted: int
+    finished: Optional[int]
     priority: str
     files_processed: int
     files_matched: int


### PR DESCRIPTION
Right now it's not possible to check how long the query took,
and it's a pretty interesting information (at least for me, the developer).

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [ ] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #issuenumber
